### PR TITLE
Adds Date parser, date sorting and alpha numeric sort for shelfmark

### DIFF
--- a/date_parser.py
+++ b/date_parser.py
@@ -9,12 +9,10 @@ from dateutil import parser
 
 
 
-RANGE = re.compile(r"(.*)/(.*)")
-YEAR = re.compile(r"\b(\d\d\d\d|\d\d\d)\b")
+NORMALIZED_RANGE = re.compile(r"(.*)/(.*)")
 
-# pylint: disable=duplicate-code
-def get_dates(dates: typing.Any):
-    """Maps a list of 'normalized_date' strings to a sorted list of integer years.
+def get_dates(normalized_dates: typing.Any):
+    """Maps a list of 'normalized_date' strings to a sorted list of datetime.
 
     Args:
         dates: A list of strings containing dates in the 'normalized_date' format.
@@ -23,13 +21,13 @@ def get_dates(dates: typing.Any):
         A list of years extracted from "dates".
 
     """
-    if not isinstance(dates, typing.Iterable):
+    if not isinstance(normalized_dates, typing.Iterable):
         return []
     solr_dts = set()
-    for date in dates:
-        if not isinstance(date, str):
+    for normalized_date in normalized_dates:
+        if not isinstance(normalized_date, str):
             continue
-        match = RANGE.search(date)
+        match = NORMALIZED_RANGE.search(normalized_date)
         if match:
             start_str, end_str = match.groups()
             start = get_date(start_str)
@@ -37,7 +35,7 @@ def get_dates(dates: typing.Any):
             if start and end:
                 solr_dts.update({start, end})
         else:
-            solr_date = get_date(date)
+            solr_date = get_date(normalized_date)
             if solr_date:
                 solr_dts.add(solr_date)
     return sorted(solr_dts)

--- a/date_parser.py
+++ b/date_parser.py
@@ -12,7 +12,7 @@ from dateutil import parser
 RANGE = re.compile(r"(.*)/(.*)")
 YEAR = re.compile(r"\b(\d\d\d\d|\d\d\d)\b")
 
-
+# pylint: disable=duplicate-code
 def get_dates(dates: typing.Any):
     """Maps a list of 'normalized_date' strings to a sorted list of integer years.
 

--- a/date_parser.py
+++ b/date_parser.py
@@ -1,0 +1,62 @@
+"""
+Creates a multi-valued 'year_isim' field by parsing input strings.
+"""
+
+import re
+import typing
+from datetime import datetime
+from dateutil import parser
+
+
+
+RANGE = re.compile(r"(.*)/(.*)")
+YEAR = re.compile(r"\b(\d\d\d\d|\d\d\d)\b")
+
+
+def get_dates(dates: typing.Any):
+    """Maps a list of 'normalized_date' strings to a sorted list of integer years.
+
+    Args:
+        dates: A list of strings containing dates in the 'normalized_date' format.
+
+    Returns:
+        A list of years extracted from "dates".
+
+    """
+    if not isinstance(dates, typing.Iterable):
+        return []
+    solr_dts = set()
+    for date in dates:
+        if not isinstance(date, str):
+            continue
+        match = RANGE.search(date)
+        if match:
+            start_str, end_str = match.groups()
+            start = get_date(start_str)
+            end = get_date(end_str)
+            if start and end:
+                solr_dts.update({start, end})
+        else:
+            solr_date = get_date(date)
+            if solr_date:
+                solr_dts.add(solr_date)
+    return sorted(solr_dts)
+
+
+def get_date(date: str):
+    """Extracts the single 4-digit year found in the input date string.
+
+    Args:
+        date: a string containing a date in 'normalized_date' format.
+
+    Returns:
+        A single date.
+
+    """
+    try:
+        parsed_date = parser.parse(date, default=datetime(1978, 1, 1))
+        return parsed_date
+    except ValueError as err:
+        print(err)
+        return None
+    return None

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -47,8 +47,7 @@
 
 <schema name="Hydra Demo Index" version="1.5">
   <!-- attribute "name" is the name of this schema and is only used for display purposes.
-       Applications should change this to reflect the nature of the search collection.
-       version="1.4" is Solr's version number for the schema syntax and semantics.  It should
+       Applications should change this to reflect the nature of the search collection. version="1.4" is Solr's version number for the schema syntax and semantics.  It should
        not normally be changed by applications.
        1.0: multiValued attribute did not exist, all fields are multiValued by nature
        1.1: multiValued attribute introduced, false by default
@@ -59,29 +58,29 @@
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
+
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
+
+
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
       definition is created matching *___<typename>.  Alternately, if 
@@ -94,25 +93,25 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
+
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
+
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
-    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-    
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -120,7 +119,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
     <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
@@ -129,12 +128,32 @@
         <filter class="solr.TrimFilterFactory" />
       </analyzer>
     </fieldtype>
-    
+    <!-- sorts text with alphabets and numbers-->
+    <fieldType name="alphaNumericSort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
+      <analyzer>
+        <!-- KeywordTokenizer does no actual tokenizing, so the entire
+            input string is preserved as a single token -->
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <!-- The LowerCase TokenFilter does what you expect, which can be
+            when you want your sorting to be case insensitive -->
+        <filter class="solr.LowerCaseFilterFactory" />
+        <!-- The TrimFilter removes any leading or trailing whitespace -->
+        <filter class="solr.TrimFilterFactory" />
+        <!-- Left-pad numbers with zeroes -->
+        <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="00000$1" replace="all" />
+        <!-- Left-trim zeroes to produce 6 digit numbers -->
+        <filter class="solr.PatternReplaceFilterFactory" pattern="0*([0-9]{6,})" replacement="$1" replace="all" />
+        <!-- Remove all but alphanumeric characters -->
+        <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9])" replacement="" replace="all" />
+      </analyzer>
+    </fieldType>
+
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
-        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->
         <filter class="solr.EnglishMinimalStemFilterFactory"/>
@@ -144,7 +163,7 @@
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- queries for paths match documents at that path, or in descendent paths -->
     <fieldType name="descendent_path" class="solr.TextField">
       <analyzer type="index">
@@ -154,7 +173,7 @@
         <tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    
+
     <!-- queries for paths match documents at that path, or in ancestor paths -->
     <fieldType name="ancestor_path" class="solr.TextField">
       <analyzer type="index">
@@ -179,15 +198,16 @@
   <fields>
     <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
     or Solr won't start. _version_ and update log are required for SolrCloud
-    --> 
+    -->
     <field name="_version_" type="long" indexed="true" stored="true"/>
-   
+
     <field name="id" type="string" stored="true" indexed="true" multiValued="false" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
-    
+
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
-
+    <field name="date_dtsort" type="date" indexed="true" stored="true" multiValued="false"/>
+    <field name="shelfmark_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="true" multiValued="false"/>
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- text (_t...) -->
@@ -201,7 +221,7 @@
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- English text (_te...) -->
     <dynamicField name="*_tei" type="text_en" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_teim" type="text_en" stored="false" indexed="true" multiValued="true"/>
@@ -213,7 +233,7 @@
     <dynamicField name="*_teimv" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesiv" type="text_en" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tesimv" type="text_en" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
+
     <!-- string (_s...) -->
     <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
@@ -222,7 +242,8 @@
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ssort" type="alphaSort" stored="false" indexed="true" multiValued="false"/>
-    
+    <!--dynamicField name="*_alpha_numeric_ssort" type="alphaNumericSort" stored="true" indexed="true" multiValued="false"/-->
+
     <!-- integer (_i...) -->
     <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
@@ -230,7 +251,7 @@
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie integer (_it...) (for faster range queries) -->
     <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
@@ -238,7 +259,7 @@
     <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- date (_dt...) -->
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z -->
@@ -248,7 +269,7 @@
     <dynamicField name="*_dtsm" type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi" type="date" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie date (_dtt...) (for faster range queries) -->
     <dynamicField name="*_dtti" type="tdate" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttim" type="tdate" stored="false" indexed="true" multiValued="true"/>
@@ -256,7 +277,7 @@
     <dynamicField name="*_dttsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dttsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dttsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- long (_l...) -->
     <dynamicField name="*_li" type="long" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_lim" type="long" stored="false" indexed="true" multiValued="true"/>
@@ -264,7 +285,7 @@
     <dynamicField name="*_lsm" type="long" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_lsi" type="long" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_lsim" type="long" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie long (_lt...) (for faster range queries) -->
     <dynamicField name="*_lti" type="tlong" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltim" type="tlong" stored="false" indexed="true" multiValued="true"/>
@@ -272,7 +293,7 @@
     <dynamicField name="*_ltsm" type="tlong" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ltsi" type="tlong" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ltsim" type="tlong" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- double (_db...) -->
     <dynamicField name="*_dbi" type="double" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbim" type="double" stored="false" indexed="true" multiValued="true"/>
@@ -280,7 +301,7 @@
     <dynamicField name="*_dbsm" type="double" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbsi" type="double" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbsim" type="double" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie double (_dbt...) (for faster range queries) -->
     <dynamicField name="*_dbti" type="tdouble" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtim" type="tdouble" stored="false" indexed="true" multiValued="true"/>
@@ -288,7 +309,7 @@
     <dynamicField name="*_dbtsm" type="tdouble" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dbtsi" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dbtsim" type="tdouble" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- float (_f...) -->
     <dynamicField name="*_fi" type="float" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_fim" type="float" stored="false" indexed="true" multiValued="true"/>
@@ -296,7 +317,7 @@
     <dynamicField name="*_fsm" type="float" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_fsi" type="float" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_fsim" type="float" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- trie float (_ft...) (for faster range queries) -->
     <dynamicField name="*_fti" type="tfloat" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftim" type="tfloat" stored="false" indexed="true" multiValued="true"/>
@@ -304,14 +325,14 @@
     <dynamicField name="*_ftsm" type="tfloat" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ftsi" type="tfloat" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ftsim" type="tfloat" stored="true" indexed="true" multiValued="true"/>
-    
+
     <!-- boolean (_b...) -->
     <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false" />
 
     <!-- location (_ll...) -->
     <dynamicField name="*_lli" type="location" stored="false" indexed="true" multiValued="false"/>
@@ -329,35 +350,35 @@
 
   </fields>
 
- <!-- Field to use to determine and enforce document uniqueness. 
+  <!-- Field to use to determine and enforce document uniqueness. 
       Unless this field is marked with required="false", it will be a required field
    -->
- <uniqueKey>id</uniqueKey>
+  <uniqueKey>id</uniqueKey>
 
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
-   <!-- Copy Fields -->
+  <!-- Copy Fields -->
 
-   <!-- Above, multiple source fields are copied to the [text] field.
+  <!-- Above, multiple source fields are copied to the [text] field.
     Another way to map multiple source fields to the same
     destination field is to use the dynamic field syntax.
     copyField also supports a maxChars to copy setting.  -->
+  <copyField source="shelfmark_ssi" dest="shelfmark_alpha_numeric_ssort" />
+  <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+  <!-- for suggestions -->
+  <copyField source="*_tesim" dest="suggest"/>
+  <copyField source="*_ssim" dest="suggest"/>
 
-   <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
-   <!-- for suggestions -->
-   <copyField source="*_tesim" dest="suggest"/>
-   <copyField source="*_ssim" dest="suggest"/>
-
- <!-- Similarity is the scoring routine for each document vs. a query.
+  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine
       for most applications.  -->
- <!-- <similarity class="org.apache.lucene.search.DefaultSimilarity"/> -->
- <!-- ... OR ...
+  <!-- <similarity class="org.apache.lucene.search.DefaultSimilarity"/> -->
+  <!-- ... OR ...
       Specify a SimilarityFactory class name implementation
       allowing parameters to be used.
  -->
- <!--
+  <!--
  <similarity class="com.example.solr.CustomSimilarityFactory">
    <str name="paramkey">param value</str>
  </similarity>

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -365,6 +365,7 @@
     destination field is to use the dynamic field syntax.
     copyField also supports a maxChars to copy setting.  -->
   <copyField source="shelfmark_ssi" dest="shelfmark_alpha_numeric_ssort" />
+  <copyField source="shelfmark_ssi" dest="shelfmark_tsi" />
   <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
   <!-- for suggestions -->
   <copyField source="*_tesim" dest="suggest"/>

--- a/test/test_date_parser.py
+++ b/test/test_date_parser.py
@@ -1,0 +1,77 @@
+"""
+tests for year_parser.py
+
+Creates a multi-valued 'year_isim' field by parsing 'normalized_date'.
+"""
+
+import datetime
+import date_parser
+
+
+def test_iso_8601():
+    """Parses an iso 8601 standard string"""
+    test_date = datetime.datetime(1941, 10, 1)
+    assert date_parser.get_dates(["1941-10-01"]) == [test_date]
+
+def test_just_year():
+    """Parses a bare year."""
+    test_date = datetime.datetime(1953, 1, 1)
+    assert date_parser.get_dates(["1953"]) == [test_date]
+
+def test_year_and_month():
+    """Parses YYYY-MM"""
+    test_date = datetime.datetime(1953, 10, 1)
+    assert date_parser.get_dates(["1953-10"]) == [test_date]
+
+def test_multiple_dates():
+    """Parses multiple input values into a list of outputs."""
+    test_dates = [
+        datetime.datetime(1941, 10, 1),
+        datetime.datetime(1935, 1, 1),
+        datetime.datetime(1945, 1, 1)
+    ]
+    assert date_parser.get_dates(["1941-10-01", "1935", "1945"]) == sorted(test_dates)
+
+def test_empty():
+    """Returns an empty list if given an empty input."""
+    assert date_parser.get_dates([]) == []
+
+def test_unparseable():
+    """Doesn't return anything for unparseable values, but still parses other elements in input."""
+    test_date = datetime.datetime(1953, 1, 1)
+    assert date_parser.get_dates(["1953", "[between 1928-1939]"]) == [test_date]
+
+def test_range():
+    """Parses YYYY/YYYY into dates."""
+
+    assert date_parser.get_dates(["1937/1939", "1942/1943"]) == [
+        datetime.datetime(1937, 1, 1),
+        datetime.datetime(1939, 1, 1),
+        datetime.datetime(1942, 1, 1),
+        datetime.datetime(1943, 1, 1)
+    ]
+
+    #Parses YYY/YYYY into dates.
+
+    assert date_parser.get_dates(["990/1000"]) == [
+        datetime.datetime(990, 1, 1),
+        datetime.datetime(1000, 1, 1)
+    ]
+
+def test_range_with_months():
+    """Months can be included in range elements, but are ingored."""
+
+    assert date_parser.get_dates(["1934-06/1934-07"]) == [
+        datetime.datetime(1934, 6, 1),
+        datetime.datetime(1934, 7, 1)
+    ]
+
+
+def test_duplicates():
+    """Deduplicates elements in output."""
+
+    assert date_parser.get_dates(["1934-06/1935-07", "1934-06-01", "1934"]) == [
+        datetime.datetime(1934, 1, 1),
+        datetime.datetime(1934, 6, 1),
+        datetime.datetime(1935, 7, 1)
+    ]

--- a/year_parser.py
+++ b/year_parser.py
@@ -9,7 +9,7 @@ import typing
 RANGE = re.compile(r"(.*)/(.*)")
 YEAR = re.compile(r"\b(\d\d\d\d|\d\d\d)\b")
 
-
+# pylint: disable=duplicate-code
 def integer_years(dates: typing.Any) -> typing.List[int]:
     """Maps a list of 'normalized_date' strings to a sorted list of integer years.
 

--- a/year_parser.py
+++ b/year_parser.py
@@ -9,7 +9,6 @@ import typing
 RANGE = re.compile(r"(.*)/(.*)")
 YEAR = re.compile(r"\b(\d\d\d\d|\d\d\d)\b")
 
-# pylint: disable=duplicate-code
 def integer_years(dates: typing.Any) -> typing.List[int]:
     """Maps a list of 'normalized_date' strings to a sorted list of integer years.
 


### PR DESCRIPTION
Connected to [URS-944](https://jira.library.ucla.edu/browse/URS-944)
This PR adds a date parser to convert normalied dates to solr dates
It also adds a new solr field for alpha numeric sort in schema.xml, to be used for shelfmark sorting by copying the shelfmark_ssi to shelfmark_alpha_numeric_ssort field in schema.xml