### PR TITLE
ci: automatically tag version in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,32 @@ jobs:
           pip install poetry
           poetry install --only main,test
       - run: poetry run pytest
+
+  tag-release:
+    needs: [pytest]
+    runs-on: ubuntu-latest
+    env:
+      BUMP_LEVEL:
+    steps:
+    - if: ${{ !env.BUMP_LEVEL && (contains(github.event.pull_request.title, '#norelease') || contains(github.event.pull_request.body, '#norelease') || contains(github.event.head_commit.message, '#norelease')) }}
+      run: echo "BUMP_LEVEL=#norelease" >> $GITHUB_ENV
+    - if: contains(github.event.pull_request.title, '#patch') || contains(github.event.pull_request.body, '#patch') || contains(github.event.head_commit.message, '#patch')
+      run: echo "BUMP_LEVEL=patch" >> $GITHUB_ENV
+    - if: contains(github.event.pull_request.title, '#minor') || contains(github.event.pull_request.body, '#minor') || contains(github.event.head_commit.message, '#minor')
+      run: echo "BUMP_LEVEL=minor" >> $GITHUB_ENV
+    - if: contains(github.event.pull_request.title, '#major') || contains(github.event.pull_request.body, '#major') || contains(github.event.head_commit.message, '#major')
+      run: echo "BUMP_LEVEL=major" >> $GITHUB_ENV
+
+    - uses: phish108/autotag-action@v1.1.55
+      if: ${{ env.BUMP_LEVEL && env.BUMP_LEVEL != '#norelease' }}
+      with:
+        dry-run: ${{ github.ref != 'refs/heads/main' || github.event_name == 'pull_request' }}
+        with-v: true
+        branch: ${{ github.base_ref || github.ref }}
+        bump: ${{ env.BUMP_LEVEL }}
+      #   github-token: ${{ secrets.GITHUB_TOKEN}}
+
+    - if: ${{!env.BUMP_LEVEL && github.event_name == 'pull_request'}}
+      run: |
+        echo "PR title or body must contain one of '#major', '#minor', '#patch', or '#norelease'."
+        exit 1


### PR DESCRIPTION
Version number will increment based on the labels #major, #minor, and #patch included in the pull request title or description. The tag #norelease can be used to allow a merge without triggering a release, otherwise the job will fail if none of the four tags are found.

The tags above in this description will trigger a major version increment, which isn't semantically appropriate but will start us off on a nice 1.0.0