### PR TITLE
Revert "fix: don't use api token for pypi (rely on trusted publisher)…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,5 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
… (#77)"

This reverts commit a9577a46b0629152959dcee7ba78c38ed4addda1.