### PR TITLE
change warning for missing thumbnails to debug only

### DIFF
--- a/feed_sinai/solr_record.py
+++ b/feed_sinai/solr_record.py
@@ -578,7 +578,7 @@ class ManuscriptSolrRecord(st.BaseModel):
             if iiif.thumbnail:
                 return iiif.thumbnail
 
-        logging.warning(f"no thumbnail for {self.ms_obj.ark}")
+        logging.debug(f"no thumbnail for {self.ms_obj.ark}")
         return None
 
     @computed_field


### PR DESCRIPTION
We usually don't have thumbnails assigned (only where we want to specify), so the warning creates a lot of noise. I updated so that missing thumbnails show on debug, not give a warning.