### PR TITLE
refactor `feed_ursus dump` and `feed_ursus loaddump`

### DIFF
--- a/feed_ursus/feed_ursus.py
+++ b/feed_ursus/feed_ursus.py
@@ -162,21 +162,40 @@ def reindex(
 
 
 @feed_ursus.command()
+@click.option(
+    "--filename-prefix",
+    type=click.STRING,
+    default="dump",
+    help="Prefix for filenames.",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(1, None),
+    default=10000,
+    help="Number of records to save per file.",
+)
 @click.pass_context
-def dump(ctx: click.Context):
-    """Write entire index to stdout.
-
-    Output will be written in jsonl format: json-formatted records separated by
-    newlines. To write to disk, use the `>` redirect operator. The resulting file can
-    then be loaded into a different solr index via the solr post tool
-    (https://solr.apache.org/guide/8_11/post-tool.html), the solr GUI console, or the
-    solr rest API. Solr generally requires the `.jsonl` suffix; if you use `.json` solr
-    will expect a single json object and fail to parse the newline-separated records.
+def dump(ctx: click.Context, filename_prefix: str, batch_size: int):
+    """Write entire index to disk.
 
     Example:
-        >>> feed_ursus dump > dump.jsonl  # writes output to `dump.jsonl`
+        >>> feed_ursus dump --filename-prefix data
+        # writes output to `data01.jsonl`, `data02.jsonl`, etc.
     """
-    ctx.obj["importer"].dump()
+    ctx.obj["importer"].dump(filename_prefix=filename_prefix, batch_size=batch_size)
+
+
+@feed_ursus.command()
+@click.pass_context
+@click.argument("filenames", nargs=-1, type=click.Path(exists=True, dir_okay=False))
+def loaddump(ctx: click.Context, filenames: tuple[str, ...]):
+    """
+    Reload data saved with 'feed_ursus dump'.
+
+    Example:
+        >>> feed_ursus load_dump data*.jsonl
+    """
+    ctx.obj["importer"].load_dump(filenames)
 
 
 class PyPIInfo(BaseModel):

--- a/feed_ursus/feed_ursus.py
+++ b/feed_ursus/feed_ursus.py
@@ -165,13 +165,13 @@ def reindex(
 @click.option(
     "--filename-prefix",
     type=click.STRING,
-    default="dump",
+    default="data",
     help="Prefix for filenames.",
 )
 @click.option(
     "--batch-size",
     type=click.IntRange(1, None),
-    default=10000,
+    default=1000,
     help="Number of records to save per file.",
 )
 @click.pass_context

--- a/feed_ursus/importer.py
+++ b/feed_ursus/importer.py
@@ -348,7 +348,7 @@ class Importer:
             with open(filename, "r", encoding="utf-8") as file:
                 for line in file:
                     try:
-                        batch.append(reindex_record(json.loads(line)))
+                        batch.append(reindex_record(json.loads(line), check=False))
                     except pydantic.ValidationError as e:
                         label = id_for_debugging(json.loads(line))
                         logging.warning(f"Could not import {label}: {e}")

--- a/feed_ursus/importer.py
+++ b/feed_ursus/importer.py
@@ -3,13 +3,13 @@
 
 import csv
 import importlib.metadata
+import json
 import logging
-import sys
 import typing
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from getpass import getuser
-from math import inf
+from math import ceil, inf
 from pathlib import Path
 
 import click
@@ -320,38 +320,40 @@ class Importer:
 
         rich.print(f"{n_errors} records could not be reindexed.")
 
-    def dump(self, output: typing.TextIO = sys.stdout) -> None:
+    def dump(self, filename_prefix: str, batch_size: int) -> None:
         hits = int(self.solr_client.search("ark_ssi:*", rows=0).hits)
-        rows = 250
 
-        for start in range(0, hits, rows):
+        # number of digits in file suffix
+        n_files = ceil(hits / batch_size)
+        digits = 0 if n_files == 1 else len(str(n_files))
+
+        for n in self.maybe_progress(range(n_files), "Saving"):
             results = self.solr_client.search(
                 "ark_ssi:*",
-                start=start,
-                rows=rows,
-            )
-            hits = results.hits
-            for raw_doc in results:
-                self.save_record(raw_doc, output)
-
-    def save_record(
-        self,
-        record: dict[str, typing.Any],
-        output: typing.TextIO = sys.stdout,
-    ):
-        try:
-            doc = UrsusSolrRecord.model_validate(record)
-
-            output.write(
-                doc.model_dump_json(
-                    by_alias=True,
-                    exclude_none=True,
-                )
-                + "\n"
+                start=n * batch_size,
+                rows=batch_size,
             )
 
-        except pydantic.ValidationError as e:
-            logging.warning(f"Could not export {record.get('id', record)}: {e}")
+            suffix = "" if digits == 0 else str(n + 1).zfill(digits)
+            filename = filename_prefix + suffix + ".jsonl"
+
+            with open(filename, "w", encoding="utf-8") as file:
+                for raw_doc in results:
+                    json.dump(raw_doc, file)
+                    file.write("\n")
+
+    def load_dump(self, filenames: Iterable[str]) -> None:
+        for filename in self.maybe_progress(filenames, "loading"):
+            batch = []
+            with open(filename, "r", encoding="utf-8") as file:
+                for line in file:
+                    try:
+                        batch.append(reindex_record(json.loads(line)))
+                    except pydantic.ValidationError as e:
+                        label = id_for_debugging(json.loads(line))
+                        logging.warning(f"Could not import {label}: {e}")
+
+            self.solr_client.add(batch)
 
     def map_record(self, record: dict[str, str]) -> UrsusSolrRecord:
         related_record_links = [

--- a/feed_ursus/importer.py
+++ b/feed_ursus/importer.py
@@ -320,7 +320,7 @@ class Importer:
 
         rich.print(f"{n_errors} records could not be reindexed.")
 
-    def dump(self, filename_prefix: str, batch_size: int) -> None:
+    def dump(self, filename_prefix: str = "data", batch_size: int = 1000) -> None:
         hits = int(self.solr_client.search("ark_ssi:*", rows=0).hits)
 
         # number of digits in file suffix

--- a/feed_ursus/reindex.py
+++ b/feed_ursus/reindex.py
@@ -28,7 +28,7 @@ class UnexplainedChangesError(ValueError):
 #
 
 
-def reindex_record(record: Any) -> dict[str, Any]:  # noqa: ANN401 (any-type)
+def reindex_record(record: Any, check: bool = True) -> dict[str, Any]:  # noqa: ANN401 (any-type)
     fixed = fix_for_reindex(deepcopy(record))
     validated = LessStrictSolrRecord.model_validate(fixed).model_dump(
         mode="json",
@@ -36,9 +36,7 @@ def reindex_record(record: Any) -> dict[str, Any]:  # noqa: ANN401 (any-type)
         exclude_none=True,
     )
 
-    if normalized_diff := get_record_diff(fixed, validated):
-        # rich.print(Rule(title=get_handle(record)))
-        # print(normalized_diff)
+    if check and (normalized_diff := get_record_diff(fixed, validated)):
         raise UnexplainedChangesError(normalized_diff)
 
     return validated

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -2,8 +2,8 @@
 
 """Tests for feed_ursus.py"""
 
-import io
-import json
+import tempfile
+from pathlib import Path
 from typing import cast
 from unittest.mock import Mock
 
@@ -224,91 +224,74 @@ def test_titles_from_solr() -> None:
     raise NotImplementedError
 
 
-class TestDump:
-    def test_dump_calls_search_and_save_record(self, importer: Importer) -> None:
-        output = io.StringIO()
-        # Mock the solr search to return some hits and docs
+def test_dump(importer: Importer) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename_prefix = str(Path(tmpdir) / "dump")
+
+        # Mock solr search
         mock_docs = [
-            {
-                "id": "54321-89112",
-                "title_tesim": ["Title"],
-                "ark_ssi": "ark:/21198/12345",
-            },
-            {
-                "id": "09876-89112",
-                "title_tesim": ["Title"],
-                "ark_ssi": "ark:/21198/67890",
-            },
+            {"ark_ssi": "ark:/21198/1", "title_tesim": ["Title 1"]},
+            {"ark_ssi": "ark:/21198/2", "title_tesim": ["Title 2"]},
         ]
         mock_result = Mock()
-        mock_result.docs = mock_docs
-        mock_result.hits = 2
         mock_result.__iter__ = Mock(return_value=iter(mock_docs))
         cast(Mock, importer.solr_client).search.side_effect = [
-            Mock(hits=2),  # First call for hits
+            Mock(hits=2),  # First call for total hits
             mock_result,  # Second call for docs
         ]
 
-        importer.dump(output)
+        importer.dump(filename_prefix=filename_prefix, batch_size=10000)
 
-        # Check that search was called correctly
-        assert cast(Mock, importer.solr_client).search.call_count == 2
-        cast(Mock, importer.solr_client).search.assert_any_call("ark_ssi:*", rows=0)
-        cast(Mock, importer.solr_client).search.assert_any_call(
-            "ark_ssi:*",
-            start=0,
-            rows=250,
+        # Verify file was created without suffix
+        output_file = Path(filename_prefix + ".jsonl")
+        assert output_file.exists()
+        assert (
+            output_file.read_text(encoding="utf-8")
+            == '{"ark_ssi": "ark:/21198/1", "title_tesim": ["Title 1"]}\n{"ark_ssi": "ark:/21198/2", "title_tesim": ["Title 2"]}\n'
         )
 
-        # Check output
-        output_str = output.getvalue().strip()
-        output_lines = output_str.split("\n")
-        assert len(output_lines) == 2  # Two records
 
-        # Parse JSON and check
-        for line in output_lines:
-            record = json.loads(line)
-            assert "id" in record
+def test_load_dump_single_file(importer: Importer) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a dump file with valid records
+        dump_file = Path(tmpdir) / "dump.jsonl"
+        dump_file.write_text(
+            '{"ark_ssi": "ark:/21198/1", "title_tesim": ["Title 1"]}'
+            "\n"
+            '{"ark_ssi": "ark:/21198/2", "title_tesim": ["Title 2"]}'
+        )
 
-    def test_save_record_valid(self, importer: Importer) -> None:
-        output = io.StringIO()
-        valid_record = {
-            "id": "54321-89112",
-            "title_tesim": ["Title"],
-            "ark_ssi": "ark:/21198/12345",
-            "visibility_ssi": "open",
-        }
+        importer.load_dump([str(dump_file)])
 
-        importer.save_record(valid_record, output)
-
-        output_str = output.getvalue().strip()
-        assert output_str  # Should have output now
-
-        parsed = json.loads(output_str)
-        assert parsed == {
-            **valid_record,
-            "discover_access_group_ssim": ["public"],
-            "download_access_group_ssim": ["public"],
-            "has_model_ssim": ["Work"],
-            "read_access_group_ssim": ["public"],
-            "sort_title_ssort": "Title",
-            "timestamp": "2026-05-19T19:20:00Z",
-            "title_sim": ["Title"],
-            "visibility_ssi": "open",
-        }
-
-    def test_save_record_invalid(self, importer: Importer, minimal_solr_record) -> None:
-        output = io.StringIO()
-        invalid_record = {
-            **minimal_solr_record,
-            "id": None,  # handles bad id (computed field)
-        }
-        invalid_record.pop("title_tesim")  # handles missing title (normally required)
-
-        importer.save_record(invalid_record, output)
-
-        output_str = output.getvalue().strip()
-        assert output_str == ""
+        # Verify add was called with correct records
+        cast(Mock, importer.solr_client).add.assert_called_once()
+        added_records = cast(Mock, importer.solr_client).add.call_args[0][0]
+        assert added_records == [
+            {
+                "ark_ssi": "ark:/21198/1",
+                "title_tesim": ["Title 1"],
+                "system_modified_dtsi": "2026-05-19T19:20:00Z",
+                "id": "1-89112",
+                "sort_title_ssort": "Title 1",
+                "timestamp": "2026-05-19T19:20:00Z",
+                "title_sim": ["Title 1"],
+                "discover_access_group_ssim": [],
+                "download_access_group_ssim": [],
+                "read_access_group_ssim": [],
+            },
+            {
+                "ark_ssi": "ark:/21198/2",
+                "title_tesim": ["Title 2"],
+                "system_modified_dtsi": "2026-05-19T19:20:00Z",
+                "id": "2-89112",
+                "sort_title_ssort": "Title 2",
+                "timestamp": "2026-05-19T19:20:00Z",
+                "title_sim": ["Title 2"],
+                "discover_access_group_ssim": [],
+                "download_access_group_ssim": [],
+                "read_access_group_ssim": [],
+            },
+        ]
 
 
 class TestGetTitles:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -50,16 +50,6 @@ def test_feed_ursus():
     ]
     assert work_record["member_of_collection_ids_ssim"] == ["xp6xn100zz-89112"]
 
-    # Test dump command
-    result = runner.invoke(
-        feed_ursus.feed_ursus,
-        ["--solr_url", SOLR_URL, "dump"],
-    )
-    assert result.exit_code == 0
-    # Since there are records, output should not be empty
-    # but this isn't currently working because we don't use `click.echo` to write the data, and the click test runner doesn't capture stdout otherwise.
-    # assert result.output.strip() != ""
-
     # Delete and confirm
     result = runner.invoke(
         feed_ursus.feed_ursus,


### PR DESCRIPTION
Instead of doing mapping / reindexing logic in the dump command, we save an unchanged record of what is currently in solr and apply reindexing logic in the new `feed_ursus loaddump`.

This will allow data fixtures in the ursus repo to be more stable, representing the kind of legacy data we work with.