### PR TITLE
DLSR-398: add 'query' argument for selective reindexing

### DIFF
--- a/feed_ursus/feed_ursus.py
+++ b/feed_ursus/feed_ursus.py
@@ -121,6 +121,20 @@ def validate(ctx: click.Context, start: int = 0, max_errors: int | None = None):
 
 @feed_ursus.command()
 @click.pass_context
+@click.argument("query", nargs=1, type=click.STRING, default="ark_ssi:*")
+def count(ctx: click.Context, query: str = "ark_ssi:*"):
+    """Display the number of items matching QUERY.
+
+    Example:
+        >>> feed_ursus count "NOT sort_title_tsort:*"
+
+        Displays number of records missing the field `sort_title_tsort`
+    """
+    ctx.obj["importer"].count(query=query)
+
+
+@feed_ursus.command()
+@click.pass_context
 @click.option(
     "--start",
     type=click.IntRange(0, None),
@@ -139,8 +153,10 @@ def validate(ctx: click.Context, start: int = 0, max_errors: int | None = None):
     default=False,
     help="Check data processing but do not resubmit to solr.",
 )
+@click.argument("query", nargs=1, type=click.STRING, default="ark_ssi:*")
 def reindex(
     ctx: click.Context,
+    query: str = "ark_ssi:*",
     start: int = 0,
     max_errors: int | None = None,
     dry_run: bool = False,
@@ -155,6 +171,7 @@ def reindex(
         >>> feed_ursus reindex
     """
     ctx.obj["importer"].reindex(
+        query=query,
         start=start,
         max_errors=(max_errors or inf),
         dry_run=dry_run,

--- a/feed_ursus/importer.py
+++ b/feed_ursus/importer.py
@@ -215,6 +215,7 @@ class Importer:
     def iterate_solr_records(
         self,
         message: str,
+        query: str = "ark_ssi:*",
         start: int = 0,
     ) -> Iterable[dict[str, typing.Any]]:
         hits: int | float = inf
@@ -230,7 +231,7 @@ class Importer:
 
             while start < hits:
                 results = self.solr_client.search(
-                    "ark_ssi:*",
+                    query,
                     sort="ark_ssi asc",  # must be a field that is not changed by reindex operation # noqa: E501
                     start=start,
                     rows=rows,
@@ -245,11 +246,22 @@ class Importer:
                         progress.update(
                             task_id,
                             description=f"{message} {completed} / {hits}...",
-                            total=int(results.hits),
+                            total=hits,
                             completed=completed,
                         )
 
                 start += rows
+
+        except Exception as e:
+            # Knock the counter back to the start of the interrupted batch
+            if progress and isinstance(task_id, int):
+                progress.update(
+                    task_id,
+                    description=f"{message} {start} / {hits}...",
+                    total=hits,
+                    completed=start,
+                )
+            raise e
 
         finally:
             if progress:
@@ -277,8 +289,13 @@ class Importer:
                         f"Reindex cancelled: reached {max_errors} {term}"
                     )
 
+    def count(self, query: str = "ark_ssi:*") -> None:
+        results = self.solr_client.search(query, rows=0)
+        click.echo(f"{results.hits} items")
+
     def reindex(
         self,
+        query: str = "ark_ssi:*",
         start: int = 0,
         max_errors: int | float = inf,
         dry_run: bool = False,
@@ -286,7 +303,7 @@ class Importer:
         n_errors = 0
 
         validated = []
-        for record in self.iterate_solr_records("reindexing", start=start):
+        for record in self.iterate_solr_records("reindexing", query=query, start=start):
             try:
                 validated.append(reindex_record(record))
 


### PR DESCRIPTION
other changes:
- reset the completed item count if an error occurs before a batch of records is submitted to solr
- add "count" subcommand