### PR TITLE
DLSR-493: Add multi-part to ViewingHint

### DIFF
--- a/feed_ursus/controlled_fields.py
+++ b/feed_ursus/controlled_fields.py
@@ -144,6 +144,7 @@ ViewingHint = Enum(
         ("http://iiif.io/api/presentation/2#continuousHint", "continuous"),
         ("http://iiif.io/api/presentation/2#nonPagedHint", "non-paged"),
         ("http://iiif.io/api/presentation/2#facingPagesHint", "facing-pages"),
+        ("http://iiif.io/api/presentation/2#multiPartHint", "multi-part"),
     ),
 )
 


### PR DESCRIPTION
Fixes [DLSR-493](https://uclalibrary.atlassian.net/browse/DLSR-493), where `multi-part` was not listed as a valid value for `ViewingHint`.


[DLSR-493]: https://uclalibrary.atlassian.net/browse/DLSR-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ